### PR TITLE
feat: image grid view for different img size

### DIFF
--- a/src/components/ImageGridView/index.jsx
+++ b/src/components/ImageGridView/index.jsx
@@ -10,7 +10,7 @@ const S = {
     GridItem: styled.div`
         position: relative;
         width: 100%;
-        padding-top: calc(162% / 1); /* 황금비 1.618의 근사값. 가로 대비 세로의 높이 */
+        padding-top: 162%; /* 황금비 1.618의 근사값. 가로 대비 세로의 높이 */
         overflow: hidden;
         border-radius: 12px;
         border: 2px solid red;
@@ -27,14 +27,15 @@ const S = {
 };
 
 function getRandomNumber() {
-    var min = Math.ceil(300 / 100); // 3
-    var max = Math.floor(600 / 100); // 6
-    var randomNumber = Math.floor(Math.random() * (max - min + 1)) + min;
+    const min = Math.ceil(300 / 100); // 3
+    const max = Math.floor(600 / 100); // 6
+    const randomNumber = Math.floor(Math.random() * (max - min + 1)) + min;
     return randomNumber * 100;
 }
 
 function ImageGridView() {
-    const arr = new Array(12).fill(0);
+    const arr = new Array(7).fill(0);
+
     return (
         <S.GridWrapper>
             {arr.map((_, idx) => {

--- a/src/components/ImageGridView/index.jsx
+++ b/src/components/ImageGridView/index.jsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { styled } from "styled-components";
+
+const S = {
+    GridWrapper: styled.div`
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        grid-gap: 10px;
+    `,
+    GridItem: styled.div`
+        position: relative;
+        width: 100%;
+        padding-top: calc(162% / 1); /* 황금비 1.618의 근사값. 가로 대비 세로의 높이 */
+        overflow: hidden;
+        border-radius: 12px;
+        border: 2px solid red;
+
+        img {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+    `,
+};
+
+function getRandomNumber() {
+    var min = Math.ceil(300 / 100); // 3
+    var max = Math.floor(600 / 100); // 6
+    var randomNumber = Math.floor(Math.random() * (max - min + 1)) + min;
+    return randomNumber * 100;
+}
+
+function ImageGridView() {
+    const arr = new Array(12).fill(0);
+    return (
+        <S.GridWrapper>
+            {arr.map((_, idx) => {
+                const randomNumWidth = getRandomNumber();
+                const randomNumHeight = getRandomNumber();
+                return (
+                    <S.GridItem key={idx}>
+                        <img src={`https://placehold.co/${randomNumWidth}x${randomNumHeight}`} />
+                    </S.GridItem>
+                );
+            })}
+        </S.GridWrapper>
+    );
+}
+
+export default ImageGridView;

--- a/src/pages/Journey/index.jsx
+++ b/src/pages/Journey/index.jsx
@@ -1,11 +1,13 @@
 import React from "react";
 import ToggleRouter from "../../components/ToggleRouter";
+import ImageGridView from "../../components/ImageGridView";
 
 function Journey() {
     return (
         <div>
             Journey page
             <ToggleRouter />
+            <ImageGridView />
         </div>
     );
 }

--- a/src/pages/MyPage/index.jsx
+++ b/src/pages/MyPage/index.jsx
@@ -1,11 +1,13 @@
 import React from "react";
 import ToggleRouter from "../../components/ToggleRouter";
+import ImageGridView from "../../components/ImageGridView";
 
 function MyPage() {
     return (
         <div>
             Collections
             <ToggleRouter />
+            <ImageGridView />
         </div>
     );
 }


### PR DESCRIPTION
그리드 뷰 

1. 각자 다른 이미지 사이즈여도 같은 크기를 가지도록 만들었습니다.
2. 디바이스 사이즈의 320 px ~ 500 px 사이에 유동적으로 잘 반응합니다. 즉, 고정 크기가 아닙니다.
3. 이미지의 비율은 그냥 황금비율의 근사값을 했습니다.
4. orphan, 즉, 7개라면 마지막 남는 1개도 비율을 유지하도록 만들었습니다.

![image](https://github.com/Lv2-Recsys-01/styl-frontend/assets/54386980/9bc20495-e1f3-4f30-b1d1-fcad8831f231)
