### PR TITLE
feat: make login modal

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-    "printWidth": 200,
+    "printWidth": 120,
     "tabWidth": 4,
     "singleQuote": false,
     "semi": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "antd": "^5.6.3",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
+                "react-modal": "^3.16.1",
                 "react-router-dom": "^6.14.1",
                 "react-scripts": "5.0.1",
                 "styled-components": "^6.0.1",
@@ -8538,6 +8539,11 @@
                 "url": "https://github.com/sindresorhus/execa?sponsor=1"
             }
         },
+        "node_modules/exenv": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+            "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
+        },
         "node_modules/exit": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -16114,6 +16120,29 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
         },
+        "node_modules/react-lifecycles-compat": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+            "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+        },
+        "node_modules/react-modal": {
+            "version": "3.16.1",
+            "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.1.tgz",
+            "integrity": "sha512-VStHgI3BVcGo7OXczvnJN7yT2TWHJPDXZWyI/a0ssFNhGZWsPmB8cF0z33ewDXq4VfYMO1vXgiv/g8Nj9NDyWg==",
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.7.2",
+                "react-lifecycles-compat": "^3.0.0",
+                "warning": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18"
+            }
+        },
         "node_modules/react-refresh": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -18360,6 +18389,14 @@
             "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
             "dependencies": {
                 "makeerror": "1.0.12"
+            }
+        },
+        "node_modules/warning": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+            "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+            "dependencies": {
+                "loose-envify": "^1.0.0"
             }
         },
         "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "antd": "^5.6.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-modal": "^3.16.1",
         "react-router-dom": "^6.14.1",
         "react-scripts": "5.0.1",
         "styled-components": "^6.0.1",

--- a/src/components/Login/login.css
+++ b/src/components/Login/login.css
@@ -3,81 +3,83 @@
     top: 0;
     left: 0;
     width: 100%;
+
     height: 100%;
     background-color: rgba(256, 256, 256, 0.2);
     display: flex;
     justify-content: center;
     align-items: center;
-  }
-  
-  .background {
-    background-color: rgba(221,204,196,0.8);
-    width:80%;
-    height:550px;
+}
+
+.background {
+    background-color: rgba(221, 204, 196, 0.8);
+    width: 80%;
+    max-width: 480px;
+    min-width: 320px;
+    height: 550px;
     padding: 25px;
     border-radius: 10px;
     opacity: 0.8;
-  }
+}
 
-  .title{
+.title {
     text-align: center;
-    color:black;
-    font-size:20px;
+    color: black;
+    font-size: 20px;
     margin-bottom: 40px;
-    margin-top:40px;
-  }
+    margin-top: 40px;
+}
 
-  .wrong{
+.wrong {
     text-align: center;
-    color:red;
-    font-size:25px;
+    color: red;
+    font-size: 25px;
     margin-bottom: 40px;
-    margin-top:40px;
-  }
+    margin-top: 40px;
+}
 
-  .box{
-    margin:10px;
-  }
+.box {
+    margin: 10px;
+}
 
-  input {
-    width:100%;
-    height:50px;
+input {
+    width: 100%;
+    height: 50px;
     border-radius: 10px;
-    border-color: rgba(221,204,196,0.8);
-  }
-  
-  button {
-    background-color:var(--orange);
+    border-color: rgba(221, 204, 196, 0.8);
+}
+
+button {
+    background-color: var(--orange);
     padding: 15px;
     border-radius: 10px;
     cursor: pointer;
     width: 100%;
-  }
+}
 
-  .signup-button.disabled {
+.signup-button.disabled {
     cursor: not-allowed;
-    background-color:rgba(110,102,98,0.8);
-  }
-  
-  .signup-button:hover:not(.disabled) {
-    background-color:  orange;
-  }
-  
-  .signin-button.disabled {
+    background-color: rgba(110, 102, 98, 0.8);
+}
+
+.signup-button:hover:not(.disabled) {
+    background-color: orange;
+}
+
+.signin-button.disabled {
     cursor: not-allowed;
-    background-color:rgba(110,102,98,0.8);
-  }
-  
-  .signin-button:hover:not(.disabled) {
-    background-color:  orange;
-  }
-  
-  
-  .option {
+    background-color: rgba(110, 102, 98, 0.8);
+}
+
+.signin-button:hover:not(.disabled) {
+    background-color: orange;
+}
+
+.option {
     margin-top: 50px;
     margin-bottom: 50px;
-    font-size:20px;
+    font-size: 20px;
     color: brown;
     text-align: center;
     text-decoration: underline;
-  }
+}

--- a/src/components/Login/login.css
+++ b/src/components/Login/login.css
@@ -1,0 +1,63 @@
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(256, 256, 256, 0.2);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  
+  .background {
+    background-color: rgba(221,204,196,0.8);
+    width:80%;
+    height:500px;
+    padding: 25px;
+    border-radius: 10px;
+    opacity: 0.8;
+  }
+
+  .title{
+    text-align: center;
+    color:black;
+    font-size:20px;
+    margin-bottom: 40px;
+    margin-top:40px;
+  }
+
+  .wrong{
+    text-align: center;
+    color:red;
+    font-size:25px;
+    margin-bottom: 40px;
+    margin-top:40px;
+  }
+
+  .box{
+    margin:10px;
+  }
+
+  input {
+    width:100%;
+    height:50px;
+    border-radius: 10px;
+    border-color: rgba(221,204,196,0.8);
+  }
+  
+  button {
+    background-color: rgba(110,102,98,0.8);
+    padding: 10px;
+    border-radius: 10px;
+    cursor: pointer;
+    width: 100%;
+  }
+  
+  .option {
+    margin-top: 50px;
+    margin-bottom: 50px;
+    font-size:20px;
+    text-align: center;
+    text-decoration: underline;
+  }

--- a/src/components/Login/login.css
+++ b/src/components/Login/login.css
@@ -47,17 +47,37 @@
   }
   
   button {
-    background-color: rgba(110,102,98,0.8);
-    padding: 10px;
+    background-color:var(--orange);
+    padding: 15px;
     border-radius: 10px;
     cursor: pointer;
     width: 100%;
   }
+
+  .signup-button.disabled {
+    cursor: not-allowed;
+    background-color:rgba(110,102,98,0.8);
+  }
+  
+  .signup-button:hover:not(.disabled) {
+    background-color:  orange;
+  }
+  
+  .signin-button.disabled {
+    cursor: not-allowed;
+    background-color:rgba(110,102,98,0.8);
+  }
+  
+  .signin-button:hover:not(.disabled) {
+    background-color:  orange;
+  }
+  
   
   .option {
     margin-top: 50px;
     margin-bottom: 50px;
     font-size:20px;
+    color: brown;
     text-align: center;
     text-decoration: underline;
   }

--- a/src/components/Login/login.css
+++ b/src/components/Login/login.css
@@ -13,7 +13,7 @@
   .background {
     background-color: rgba(221,204,196,0.8);
     width:80%;
-    height:500px;
+    height:550px;
     padding: 25px;
     border-radius: 10px;
     opacity: 0.8;

--- a/src/components/Login/login.css
+++ b/src/components/Login/login.css
@@ -58,7 +58,6 @@ button {
 }
 
 .signup-button.disabled {
-    cursor: not-allowed;
     background-color: rgba(110, 102, 98, 0.8);
 }
 
@@ -67,7 +66,6 @@ button {
 }
 
 .signin-button.disabled {
-    cursor: not-allowed;
     background-color: rgba(110, 102, 98, 0.8);
 }
 

--- a/src/components/Login/login.jsx
+++ b/src/components/Login/login.jsx
@@ -13,7 +13,7 @@ function GoToLoginLessNav() {
     );
 }
 
-function Login({ closeModal }) {
+function Login({ closeModal = () => {} }) {
     const [id, setId] = useState("");
     const [password, setPassword] = useState("");
     const [modalMode, setmodalMode] = useState("login");
@@ -35,7 +35,6 @@ function Login({ closeModal }) {
     };
 
     const isSignUpDisabled = id.length < 4 || password.length !== 4;
-
     const isSignInDisabled = id.length < 4 || password.length !== 4 || confirm.length !== 4 || password !== confirm;
 
     const handleLogin = () => {
@@ -61,7 +60,7 @@ function Login({ closeModal }) {
         <Modal
             isOpen={true}
             onRequestClose={closeModal}
-            shouldCloseOnOverlayClick={true}
+            shouldCloseOnOverlayClick={false}
             className="modal"
             overlayClassName="modal-overlay"
         >

--- a/src/components/Login/login.jsx
+++ b/src/components/Login/login.jsx
@@ -58,7 +58,6 @@ function Login({ closeModal = () => {} }) {
         id.length >= 4 || password.length === 4 || confirm.length === 4 || password === confirm;
 
     const handleLogin = () => {
-        // TODO: 로그인 처리 로직 작성
         console.log(`ID: ${id}, Password: ${password}`);
 
         if (!loginValidationCondition) {
@@ -68,7 +67,6 @@ function Login({ closeModal = () => {} }) {
     };
 
     const handleSignin = () => {
-        // TODO: 회원가입 처리 로직 작성
         console.log(`ID: ${id}, Password: ${password}`);
 
         if (!signinValidationCondition) {
@@ -105,7 +103,6 @@ function Login({ closeModal = () => {} }) {
                     <div className="box">
                         <button
                             onClick={handleLogin}
-                            // disabled={loginValidationCondition}
                             className={`signup-button ${loginValidationCondition ? "disabled" : ""}`}
                         >
                             로그인
@@ -149,7 +146,6 @@ function Login({ closeModal = () => {} }) {
                     <div className="box">
                         <button
                             onClick={handleSignin}
-                            // disabled={signinValidationCondition}
                             className={`signin-button ${signinValidationCondition ? "disabled" : ""}`}
                         >
                             회원가입

--- a/src/components/Login/login.jsx
+++ b/src/components/Login/login.jsx
@@ -5,6 +5,14 @@ import { NavLink } from "react-router-dom";
 
 Modal.setAppElement("#root");
 
+function GoToLoginLessNav() {
+    return (
+        <p>
+            <NavLink to="/journey">로그인 없이 사용할래요</NavLink>
+        </p>
+    );
+}
+
 function Login({ closeModal }) {
     const [id, setId] = useState("");
     const [password, setPassword] = useState("");
@@ -106,9 +114,7 @@ function Login({ closeModal }) {
                                 회원가입할래요
                             </a>
                         </p>
-                        <p>
-                            <NavLink to="/journey">로그인 없이 사용할래요</NavLink>
-                        </p>
+                        <GoToLoginLessNav />
                     </div>
                 </div>
             </Modal>
@@ -177,9 +183,7 @@ function Login({ closeModal }) {
                                 로그인할래요
                             </a>
                         </p>
-                        <p>
-                            <NavLink to="/journey">로그인 없이 사용할래요</NavLink>
-                        </p>
+                        <GoToLoginLessNav />
                     </div>
                 </div>
             </Modal>

--- a/src/components/Login/login.jsx
+++ b/src/components/Login/login.jsx
@@ -54,16 +54,16 @@ function Login({ closeModal = () => {} }) {
         setError("");
     };
 
-    const loginValidationCondition = id.length >= 4 || password.length === 4;
-    const signinValidationCondition =
-        id.length >= 4 || password.length === 4 || confirm.length === 4 || password === confirm;
+    const checkLoginIneligibility = id.length < 4 || password.length !== 4;
+    const checkSigninIneligibility =
+        id.length < 4 || password.length !== 4 || confirm.length !== 4 || password !== confirm;
     const isSignInMode = modalMode === "signin";
     const isLogInMode = modalMode === "login";
 
     const handleLogin = () => {
         console.log(`login => ID: ${id}, Password: ${password}`);
 
-        if (!loginValidationCondition) {
+        if (checkLoginIneligibility) {
             clearInput();
             setError("검증에 실패했어요");
         }
@@ -72,7 +72,7 @@ function Login({ closeModal = () => {} }) {
     const handleSignin = () => {
         console.log(`signin => ID: ${id}, Password: ${password}`);
 
-        if (!signinValidationCondition) {
+        if (checkSigninIneligibility) {
             clearInput();
             setError("검증에 실패했어요");
         }
@@ -90,7 +90,7 @@ function Login({ closeModal = () => {} }) {
                 <h2 className="title">10초면 가입할 수 있어요!</h2>
                 <div className="box">
                     ID
-                    <input type="text" placeholder="ID" value={id} onChange={handleIdChange} maxLength={10} />
+                    <input type="text" placeholder="ID" value={id} onChange={handleIdChange} maxLength={20} />
                 </div>
                 <div className="box">
                     Password (4자리 숫자)
@@ -120,7 +120,7 @@ function Login({ closeModal = () => {} }) {
                     <div className="box">
                         <button
                             onClick={handleLogin}
-                            className={`signup-button ${loginValidationCondition ? "disabled" : ""}`}
+                            className={`signup-button ${checkLoginIneligibility ? "disabled" : ""}`}
                         >
                             로그인
                         </button>
@@ -130,7 +130,7 @@ function Login({ closeModal = () => {} }) {
                     <div className="box">
                         <button
                             onClick={handleSignin}
-                            className={`signin-button ${signinValidationCondition ? "disabled" : ""}`}
+                            className={`signin-button ${checkSigninIneligibility ? "disabled" : ""}`}
                         >
                             회원가입
                         </button>

--- a/src/components/Login/login.jsx
+++ b/src/components/Login/login.jsx
@@ -92,11 +92,11 @@ function Login({ closeModal }) {
                 <div className="background">
                     {title === "wrong" ? <h2 className={`wrong`}>다시 시도해주세요!</h2> : <h2 className="title">10초면 가입할 수 있어요!</h2>}
                     <div className="box">
-                        ID
-                        <input type="text" placeholder="숫자와 소문자만 사용 가능합니다." value={id} onChange={handleIdChange} maxLength={10} />
+                        ID (10자리 이내, 소문자와 숫자)
+                        <input type="text" placeholder="ID" value={id} onChange={handleIdChange} maxLength={10} />
                     </div>
                     <div className="box">
-                        Password
+                        Password (4자리 숫자)
                         <input type="password" placeholder="Password" value={password} onChange={handlePasswordChange} maxLength={4} />
                     </div>
                     <div className="box">

--- a/src/components/Login/login.jsx
+++ b/src/components/Login/login.jsx
@@ -35,14 +35,27 @@ function Login({ closeModal = () => {} }) {
         setConfirm(value);
     };
 
-    const loginValidationCondition = id.length < 4 || password.length !== 4;
-    const signinValidationCondition =
-        id.length < 4 || password.length !== 4 || confirm.length !== 4 || password !== confirm;
+    const handleToggleModalModeButton = (e) => {
+        e.preventDefault();
+        if (modalMode === "login") {
+            setModalMode("signin");
+        } else {
+            setModalMode("login");
+        }
+        clearInput(true);
+    };
 
-    const clearInput = () => {
+    const clearInput = (shouldClearId = false) => {
+        if (shouldClearId) {
+            setId("");
+        }
         setPassword("");
         setConfirm("");
     };
+
+    const loginValidationCondition = id.length < 4 || password.length !== 4;
+    const signinValidationCondition =
+        id.length < 4 || password.length !== 4 || confirm.length !== 4 || password !== confirm;
 
     const handleLogin = () => {
         // TODO: 로그인 처리 로직 작성
@@ -102,17 +115,7 @@ function Login({ closeModal = () => {} }) {
                     {error && <p className="error">{error}</p>}
 
                     <div className="option">
-                        <p
-                            onClick={function (event) {
-                                event.preventDefault();
-                                setModalMode("signin");
-                                setId("");
-                                setPassword("");
-                                setConfirm("");
-                            }}
-                        >
-                            회원가입할래요
-                        </p>
+                        <p onClick={handleToggleModalModeButton}>회원가입할래요</p>
                         <GoToLoginLessNav />
                     </div>
                 </div>
@@ -155,17 +158,7 @@ function Login({ closeModal = () => {} }) {
 
                     <div className="option">
                         <p>
-                            <div
-                                onClick={function (event) {
-                                    event.preventDefault();
-                                    setModalMode("login");
-                                    setId("");
-                                    setPassword("");
-                                    setConfirm("");
-                                }}
-                            >
-                                로그인할래요
-                            </div>
+                            <div onClick={handleToggleModalModeButton}>로그인할래요</div>
                         </p>
                         <GoToLoginLessNav />
                     </div>

--- a/src/components/Login/login.jsx
+++ b/src/components/Login/login.jsx
@@ -16,7 +16,7 @@ function GoToLoginLessNav() {
 function Login({ closeModal }) {
     const [id, setId] = useState("");
     const [password, setPassword] = useState("");
-    const [mode, setMode] = useState("login");
+    const [modalMode, setmodalMode] = useState("login");
     const [confirm, setConfirm] = useState("");
 
     const handleIdChange = (e) => {
@@ -57,15 +57,15 @@ function Login({ closeModal }) {
         setConfirm("");
     };
 
-    if (mode === "login") {
-        return (
-            <Modal
-                isOpen={true}
-                onRequestClose={closeModal}
-                shouldCloseOnOverlayClick={true}
-                className="modal"
-                overlayClassName="modal-overlay"
-            >
+    return (
+        <Modal
+            isOpen={true}
+            onRequestClose={closeModal}
+            shouldCloseOnOverlayClick={true}
+            className="modal"
+            overlayClassName="modal-overlay"
+        >
+            {modalMode === "login" ? (
                 <div className="background">
                     <h2 className="title">10초면 가입할 수 있어요!</h2>
                     <div className="box">
@@ -96,7 +96,7 @@ function Login({ closeModal }) {
                         <p
                             onClick={function (event) {
                                 event.preventDefault();
-                                setMode("signin");
+                                setmodalMode("signin");
                                 setId("");
                                 setPassword("");
                                 setConfirm("");
@@ -107,17 +107,7 @@ function Login({ closeModal }) {
                         <GoToLoginLessNav />
                     </div>
                 </div>
-            </Modal>
-        );
-    } else if (mode === "signin") {
-        return (
-            <Modal
-                isOpen={true}
-                onRequestClose={closeModal}
-                shouldCloseOnOverlayClick={true}
-                className="modal"
-                overlayClassName="modal-overlay"
-            >
+            ) : (
                 <div className="background">
                     <h2 className="title">10초면 가입할 수 있어요!</h2>
                     <div className="box">
@@ -159,7 +149,7 @@ function Login({ closeModal }) {
                             <div
                                 onClick={function (event) {
                                     event.preventDefault();
-                                    setMode("login");
+                                    setmodalMode("login");
                                     setId("");
                                     setPassword("");
                                     setConfirm("");
@@ -171,9 +161,9 @@ function Login({ closeModal }) {
                         <GoToLoginLessNav />
                     </div>
                 </div>
-            </Modal>
-        );
-    }
+            )}
+        </Modal>
+    );
 }
 
 export default Login;

--- a/src/components/Login/login.jsx
+++ b/src/components/Login/login.jsx
@@ -53,9 +53,9 @@ function Login({ closeModal = () => {} }) {
         setConfirm("");
     };
 
-    const loginValidationCondition = id.length < 4 || password.length !== 4;
+    const loginValidationCondition = id.length >= 4 || password.length === 4;
     const signinValidationCondition =
-        id.length < 4 || password.length !== 4 || confirm.length !== 4 || password !== confirm;
+        id.length >= 4 || password.length === 4 || confirm.length === 4 || password === confirm;
 
     const handleLogin = () => {
         // TODO: 로그인 처리 로직 작성

--- a/src/components/Login/login.jsx
+++ b/src/components/Login/login.jsx
@@ -16,7 +16,6 @@ function GoToLoginLessNav() {
 function Login({ closeModal }) {
     const [id, setId] = useState("");
     const [password, setPassword] = useState("");
-    const [title, setTitle] = useState("first");
     const [mode, setMode] = useState("login");
     const [confirm, setConfirm] = useState("");
 
@@ -45,7 +44,6 @@ function Login({ closeModal }) {
         // 로그인했으면 통과
 
         //실패시 재시도
-        setTitle("wrong");
         setPassword("");
         setConfirm("");
     };
@@ -55,7 +53,6 @@ function Login({ closeModal }) {
         console.log(`ID: ${id}, Password: ${password}`);
 
         //실패시 재시도
-        setTitle("wrong");
         setPassword("");
         setConfirm("");
     };
@@ -70,11 +67,7 @@ function Login({ closeModal }) {
                 overlayClassName="modal-overlay"
             >
                 <div className="background">
-                    {title === "wrong" ? (
-                        <h2 className={`wrong`}>다시 시도해주세요!</h2>
-                    ) : (
-                        <h2 className="title">10초면 가입할 수 있어요!</h2>
-                    )}
+                    <h2 className="title">10초면 가입할 수 있어요!</h2>
                     <div className="box">
                         ID
                         <input type="text" placeholder="ID" value={id} onChange={handleIdChange} maxLength={10} />
@@ -101,18 +94,17 @@ function Login({ closeModal }) {
 
                     <div className="option">
                         <p>
-                            <a
+                            <div
                                 onClick={function (event) {
                                     event.preventDefault();
                                     setMode("signin");
                                     setId("");
                                     setPassword("");
                                     setConfirm("");
-                                    setTitle("first");
                                 }}
                             >
                                 회원가입할래요
-                            </a>
+                            </div>
                         </p>
                         <GoToLoginLessNav />
                     </div>
@@ -129,11 +121,7 @@ function Login({ closeModal }) {
                 overlayClassName="modal-overlay"
             >
                 <div className="background">
-                    {title === "wrong" ? (
-                        <h2 className={`wrong`}>다시 시도해주세요!</h2>
-                    ) : (
-                        <h2 className="title">10초면 가입할 수 있어요!</h2>
-                    )}
+                    <h2 className="title">10초면 가입할 수 있어요!</h2>
                     <div className="box">
                         ID (10자리 이내, 소문자와 숫자)
                         <input type="text" placeholder="ID" value={id} onChange={handleIdChange} maxLength={10} />
@@ -170,18 +158,17 @@ function Login({ closeModal }) {
 
                     <div className="option">
                         <p>
-                            <a
+                            <div
                                 onClick={function (event) {
                                     event.preventDefault();
                                     setMode("login");
                                     setId("");
                                     setPassword("");
                                     setConfirm("");
-                                    setTitle("first");
                                 }}
                             >
                                 로그인할래요
-                            </a>
+                            </div>
                         </p>
                         <GoToLoginLessNav />
                     </div>

--- a/src/components/Login/login.jsx
+++ b/src/components/Login/login.jsx
@@ -16,8 +16,9 @@ function GoToLoginLessNav() {
 function Login({ closeModal = () => {} }) {
     const [id, setId] = useState("");
     const [password, setPassword] = useState("");
-    const [modalMode, setmodalMode] = useState("login");
+    const [modalMode, setModalMode] = useState("login");
     const [confirm, setConfirm] = useState("");
+    const [error, setError] = useState(false);
 
     const handleIdChange = (e) => {
         const value = e.target.value;
@@ -34,17 +35,23 @@ function Login({ closeModal = () => {} }) {
         setConfirm(value);
     };
 
-    const isSignUpDisabled = id.length < 4 || password.length !== 4;
+    const loginValidationCondition = id.length < 4 || password.length !== 4;
     const isSignInDisabled = id.length < 4 || password.length !== 4 || confirm.length !== 4 || password !== confirm;
+
+    const clearInput = () => {
+        setPassword("");
+        setConfirm("");
+    };
 
     const handleLogin = () => {
         // TODO: 로그인 처리 로직 작성
         console.log(`ID: ${id}, Password: ${password}`);
-        // 로그인했으면 통과
 
-        //실패시 재시도
-        setPassword("");
-        setConfirm("");
+        // validation
+        if (id.length < 4 || password.length !== 4) {
+            //실패시 재시도
+            clearInput();
+        }
     };
 
     const handleSignin = () => {
@@ -52,8 +59,7 @@ function Login({ closeModal = () => {} }) {
         console.log(`ID: ${id}, Password: ${password}`);
 
         //실패시 재시도
-        setPassword("");
-        setConfirm("");
+        clearInput();
     };
 
     return (
@@ -84,8 +90,8 @@ function Login({ closeModal = () => {} }) {
                     <div className="box">
                         <button
                             onClick={handleLogin}
-                            disabled={isSignUpDisabled}
-                            className={`signup-button ${isSignUpDisabled ? "disabled" : ""}`}
+                            disabled={loginValidationCondition}
+                            className={`signup-button ${loginValidationCondition ? "disabled" : ""}`}
                         >
                             로그인
                         </button>
@@ -95,7 +101,7 @@ function Login({ closeModal = () => {} }) {
                         <p
                             onClick={function (event) {
                                 event.preventDefault();
-                                setmodalMode("signin");
+                                setModalMode("signin");
                                 setId("");
                                 setPassword("");
                                 setConfirm("");
@@ -148,7 +154,7 @@ function Login({ closeModal = () => {} }) {
                             <div
                                 onClick={function (event) {
                                     event.preventDefault();
-                                    setmodalMode("login");
+                                    setModalMode("login");
                                     setId("");
                                     setPassword("");
                                     setConfirm("");

--- a/src/components/Login/login.jsx
+++ b/src/components/Login/login.jsx
@@ -51,14 +51,17 @@ function Login({ closeModal = () => {} }) {
         }
         setPassword("");
         setConfirm("");
+        setError("");
     };
 
     const loginValidationCondition = id.length >= 4 || password.length === 4;
     const signinValidationCondition =
         id.length >= 4 || password.length === 4 || confirm.length === 4 || password === confirm;
+    const isSignInMode = modalMode === "signin";
+    const isLogInMode = modalMode === "login";
 
     const handleLogin = () => {
-        console.log(`ID: ${id}, Password: ${password}`);
+        console.log(`login => ID: ${id}, Password: ${password}`);
 
         if (!loginValidationCondition) {
             clearInput();
@@ -67,7 +70,7 @@ function Login({ closeModal = () => {} }) {
     };
 
     const handleSignin = () => {
-        console.log(`ID: ${id}, Password: ${password}`);
+        console.log(`signin => ID: ${id}, Password: ${password}`);
 
         if (!signinValidationCondition) {
             clearInput();
@@ -83,56 +86,23 @@ function Login({ closeModal = () => {} }) {
             className="modal"
             overlayClassName="modal-overlay"
         >
-            {modalMode === "login" ? (
-                <div className="background">
-                    <h2 className="title">10초면 가입할 수 있어요!</h2>
-                    <div className="box">
-                        ID
-                        <input type="text" placeholder="ID" value={id} onChange={handleIdChange} maxLength={10} />
-                    </div>
-                    <div className="box">
-                        Password (4자리 숫자)
-                        <input
-                            type="password"
-                            placeholder="Password"
-                            value={password}
-                            onChange={handlePasswordChange}
-                            maxLength={4}
-                        />
-                    </div>
-                    <div className="box">
-                        <button
-                            onClick={handleLogin}
-                            className={`signup-button ${loginValidationCondition ? "disabled" : ""}`}
-                        >
-                            로그인
-                        </button>
-                    </div>
-
-                    {error && <p className="error">{error}</p>}
-
-                    <div className="option">
-                        <p onClick={handleToggleModalModeButton}>회원가입할래요</p>
-                        <GoToLoginLessNav />
-                    </div>
+            <div className="background">
+                <h2 className="title">10초면 가입할 수 있어요!</h2>
+                <div className="box">
+                    ID
+                    <input type="text" placeholder="ID" value={id} onChange={handleIdChange} maxLength={10} />
                 </div>
-            ) : (
-                <div className="background">
-                    <h2 className="title">10초면 가입할 수 있어요!</h2>
-                    <div className="box">
-                        ID (10자리 이내, 소문자와 숫자)
-                        <input type="text" placeholder="ID" value={id} onChange={handleIdChange} maxLength={10} />
-                    </div>
-                    <div className="box">
-                        Password (4자리 숫자)
-                        <input
-                            type="password"
-                            placeholder="Password"
-                            value={password}
-                            onChange={handlePasswordChange}
-                            maxLength={4}
-                        />
-                    </div>
+                <div className="box">
+                    Password (4자리 숫자)
+                    <input
+                        type="password"
+                        placeholder="Password"
+                        value={password}
+                        onChange={handlePasswordChange}
+                        maxLength={4}
+                    />
+                </div>
+                {isSignInMode && (
                     <div className="box">
                         Confirm Password
                         <input
@@ -143,6 +113,20 @@ function Login({ closeModal = () => {} }) {
                             maxLength={4}
                         />
                     </div>
+                )}
+
+                {/* 로그인, 회원가입 제출 */}
+                {isLogInMode && (
+                    <div className="box">
+                        <button
+                            onClick={handleLogin}
+                            className={`signup-button ${loginValidationCondition ? "disabled" : ""}`}
+                        >
+                            로그인
+                        </button>
+                    </div>
+                )}
+                {isSignInMode && (
                     <div className="box">
                         <button
                             onClick={handleSignin}
@@ -151,15 +135,17 @@ function Login({ closeModal = () => {} }) {
                             회원가입
                         </button>
                     </div>
+                )}
 
-                    <div className="option">
-                        <p>
-                            <div onClick={handleToggleModalModeButton}>로그인할래요</div>
-                        </p>
-                        <GoToLoginLessNav />
-                    </div>
+                {/* 에러 섹션 */}
+                {error && <p className="error">{error}</p>}
+
+                {/* modal Mode 전환 */}
+                <div className="option">
+                    <p onClick={handleToggleModalModeButton}>{isLogInMode ? "회원가입할래요" : "회원가입"}</p>
+                    <GoToLoginLessNav />
                 </div>
-            )}
+            </div>
         </Modal>
     );
 }

--- a/src/components/Login/login.jsx
+++ b/src/components/Login/login.jsx
@@ -76,7 +76,7 @@ function Login({ closeModal }) {
                     </div>
                     <div className="box">
                         Confirm Password
-                        <input type="confirm" placeholder="Confirm Password" value={confirm} onChange={(e) => setConfirm(e.target.value)} maxLength={4} />
+                        <input type="password" placeholder="Confirm Password" value={confirm} onChange={(e) => setConfirm(e.target.value)} maxLength={4} />
                     </div>
                     <div className="box">
                         <button onClick={handleLogin}>회원가입</button>

--- a/src/components/Login/login.jsx
+++ b/src/components/Login/login.jsx
@@ -28,7 +28,7 @@ function Login({ closeModal }) {
 
     const isSignUpDisabled = id.length < 4 || password.length !== 4;
 
-    const isSignInDisabled = id.length < 4 || password.length !== 4 || confirm.length !== 4;
+    const isSignInDisabled = id.length < 4 || password.length !== 4 || confirm.length !== 4 || password !== confirm;
 
     const handleLogin = () => {
         // TODO: 로그인 처리 로직 작성

--- a/src/components/Login/login.jsx
+++ b/src/components/Login/login.jsx
@@ -93,18 +93,16 @@ function Login({ closeModal }) {
                     </div>
 
                     <div className="option">
-                        <p>
-                            <div
-                                onClick={function (event) {
-                                    event.preventDefault();
-                                    setMode("signin");
-                                    setId("");
-                                    setPassword("");
-                                    setConfirm("");
-                                }}
-                            >
-                                회원가입할래요
-                            </div>
+                        <p
+                            onClick={function (event) {
+                                event.preventDefault();
+                                setMode("signin");
+                                setId("");
+                                setPassword("");
+                                setConfirm("");
+                            }}
+                        >
+                            회원가입할래요
                         </p>
                         <GoToLoginLessNav />
                     </div>

--- a/src/components/Login/login.jsx
+++ b/src/components/Login/login.jsx
@@ -1,0 +1,59 @@
+import React, { useState } from "react";
+import Modal from "react-modal";
+import "./login.css";
+
+Modal.setAppElement("#root");
+
+function Login({ closeModal }) {
+    const [id, setId] = useState("");
+    const [password, setPassword] = useState("");
+    const [title, setTitle] = useState("10초면 가입할 수 있어요!");
+    const [mode, setMode] = useState("login");
+    const wrong = title === "wrong";
+
+    const handleLogin = () => {
+        // TODO: 로그인 처리 로직 작성
+        console.log(`ID: ${id}, Password: ${password}`);
+        // 로그인했으면 통과
+
+        //실패시 재시도
+        setTitle("wrong");
+    };
+
+    return (
+        <Modal isOpen={true} onRequestClose={closeModal} shouldCloseOnOverlayClick={true} className="modal" overlayClassName="modal-overlay">
+            <div className="background">
+                {title === "wrong" ? <h2 className={`wrong`}>다시 시도해주세요!</h2> : <h2 className="title">10초면 가입할 수 있어요!</h2>}
+                <div className="box">
+                    ID
+                    <input type="text" placeholder="ID" value={id} onChange={(e) => setId(e.target.value)} />
+                </div>
+                <div className="box">
+                    Password
+                    <input type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} />
+                </div>
+                <div className="box">
+                    <button onClick={handleLogin}>로그인</button>
+                </div>
+
+                <div className="option">
+                    <p>
+                        <a
+                            href="회원가입"
+                            onClick={function (event) {
+                                event.preventDefault();
+                            }}
+                        >
+                            회원가입
+                        </a>
+                    </p>
+                    <p>
+                        <a href="/Journey">로그인 없이 사용할래요</a>
+                    </p>
+                </div>
+            </div>
+        </Modal>
+    );
+}
+
+export default Login;

--- a/src/components/Login/login.jsx
+++ b/src/components/Login/login.jsx
@@ -36,7 +36,8 @@ function Login({ closeModal = () => {} }) {
     };
 
     const loginValidationCondition = id.length < 4 || password.length !== 4;
-    const isSignInDisabled = id.length < 4 || password.length !== 4 || confirm.length !== 4 || password !== confirm;
+    const signinValidationCondition =
+        id.length < 4 || password.length !== 4 || confirm.length !== 4 || password !== confirm;
 
     const clearInput = () => {
         setPassword("");
@@ -47,10 +48,9 @@ function Login({ closeModal = () => {} }) {
         // TODO: 로그인 처리 로직 작성
         console.log(`ID: ${id}, Password: ${password}`);
 
-        // validation
-        if (id.length < 4 || password.length !== 4) {
-            //실패시 재시도
+        if (!loginValidationCondition) {
             clearInput();
+            setError("검증에 실패했어요");
         }
     };
 
@@ -58,8 +58,10 @@ function Login({ closeModal = () => {} }) {
         // TODO: 회원가입 처리 로직 작성
         console.log(`ID: ${id}, Password: ${password}`);
 
-        //실패시 재시도
-        clearInput();
+        if (!signinValidationCondition) {
+            clearInput();
+            setError("검증에 실패했어요");
+        }
     };
 
     return (
@@ -90,12 +92,14 @@ function Login({ closeModal = () => {} }) {
                     <div className="box">
                         <button
                             onClick={handleLogin}
-                            disabled={loginValidationCondition}
+                            // disabled={loginValidationCondition}
                             className={`signup-button ${loginValidationCondition ? "disabled" : ""}`}
                         >
                             로그인
                         </button>
                     </div>
+
+                    {error && <p className="error">{error}</p>}
 
                     <div className="option">
                         <p
@@ -142,8 +146,8 @@ function Login({ closeModal = () => {} }) {
                     <div className="box">
                         <button
                             onClick={handleSignin}
-                            disabled={isSignInDisabled}
-                            className={`signin-button ${isSignInDisabled ? "disabled" : ""}`}
+                            // disabled={signinValidationCondition}
+                            className={`signin-button ${signinValidationCondition ? "disabled" : ""}`}
                         >
                             회원가입
                         </button>

--- a/src/components/Login/login.jsx
+++ b/src/components/Login/login.jsx
@@ -7,9 +7,9 @@ Modal.setAppElement("#root");
 function Login({ closeModal }) {
     const [id, setId] = useState("");
     const [password, setPassword] = useState("");
-    const [title, setTitle] = useState("10초면 가입할 수 있어요!");
+    const [title, setTitle] = useState("first");
     const [mode, setMode] = useState("login");
-    const wrong = title === "wrong";
+    const [confirm, setConfirm] = useState("");
 
     const handleLogin = () => {
         // TODO: 로그인 처리 로직 작성
@@ -18,42 +18,93 @@ function Login({ closeModal }) {
 
         //실패시 재시도
         setTitle("wrong");
+        setPassword("");
+        setConfirm("");
     };
 
-    return (
-        <Modal isOpen={true} onRequestClose={closeModal} shouldCloseOnOverlayClick={true} className="modal" overlayClassName="modal-overlay">
-            <div className="background">
-                {title === "wrong" ? <h2 className={`wrong`}>다시 시도해주세요!</h2> : <h2 className="title">10초면 가입할 수 있어요!</h2>}
-                <div className="box">
-                    ID
-                    <input type="text" placeholder="ID" value={id} onChange={(e) => setId(e.target.value)} />
-                </div>
-                <div className="box">
-                    Password
-                    <input type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} />
-                </div>
-                <div className="box">
-                    <button onClick={handleLogin}>로그인</button>
-                </div>
+    if (mode === "login") {
+        return (
+            <Modal isOpen={true} onRequestClose={closeModal} shouldCloseOnOverlayClick={true} className="modal" overlayClassName="modal-overlay">
+                <div className="background">
+                    {title === "wrong" ? <h2 className={`wrong`}>다시 시도해주세요!</h2> : <h2 className="title">10초면 가입할 수 있어요!</h2>}
+                    <div className="box">
+                        ID
+                        <input type="text" placeholder="ID" value={id} onChange={(e) => setId(e.target.value)} maxLength={10} />
+                    </div>
+                    <div className="box">
+                        Password
+                        <input type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} maxLength={4} />
+                    </div>
+                    <div className="box">
+                        <button onClick={handleLogin}>로그인</button>
+                    </div>
 
-                <div className="option">
-                    <p>
-                        <a
-                            href="회원가입"
-                            onClick={function (event) {
-                                event.preventDefault();
-                            }}
-                        >
-                            회원가입
-                        </a>
-                    </p>
-                    <p>
-                        <a href="/Journey">로그인 없이 사용할래요</a>
-                    </p>
+                    <div className="option">
+                        <p>
+                            <a
+                                onClick={function (event) {
+                                    event.preventDefault();
+                                    setMode("signin");
+                                    setId("");
+                                    setPassword("");
+                                    setConfirm("");
+                                    setTitle("first");
+                                }}
+                            >
+                                회원가입할래요
+                            </a>
+                        </p>
+                        <p>
+                            <a href="/Journey">로그인 없이 사용할래요</a>
+                        </p>
+                    </div>
                 </div>
-            </div>
-        </Modal>
-    );
+            </Modal>
+        );
+    } else if (mode === "signin") {
+        return (
+            <Modal isOpen={true} onRequestClose={closeModal} shouldCloseOnOverlayClick={true} className="modal" overlayClassName="modal-overlay">
+                <div className="background">
+                    {title === "wrong" ? <h2 className={`wrong`}>다시 시도해주세요!</h2> : <h2 className="title">10초면 가입할 수 있어요!</h2>}
+                    <div className="box">
+                        ID
+                        <input type="text" placeholder="숫자와 소문자만 사용 가능합니다." value={id} onChange={(e) => setId(e.target.value)} maxLength={10} />
+                    </div>
+                    <div className="box">
+                        Password
+                        <input type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} maxLength={4} />
+                    </div>
+                    <div className="box">
+                        Confirm Password
+                        <input type="confirm" placeholder="Confirm Password" value={confirm} onChange={(e) => setConfirm(e.target.value)} maxLength={4} />
+                    </div>
+                    <div className="box">
+                        <button onClick={handleLogin}>회원가입</button>
+                    </div>
+
+                    <div className="option">
+                        <p>
+                            <a
+                                onClick={function (event) {
+                                    event.preventDefault();
+                                    setMode("login");
+                                    setId("");
+                                    setPassword("");
+                                    setConfirm("");
+                                    setTitle("first");
+                                }}
+                            >
+                                로그인할래요
+                            </a>
+                        </p>
+                        <p>
+                            <a href="/Journey">로그인 없이 사용할래요</a>
+                        </p>
+                    </div>
+                </div>
+            </Modal>
+        );
+    }
 }
 
 export default Login;

--- a/src/components/Login/login.jsx
+++ b/src/components/Login/login.jsx
@@ -11,10 +11,35 @@ function Login({ closeModal }) {
     const [mode, setMode] = useState("login");
     const [confirm, setConfirm] = useState("");
 
+    const handleIdChange = (e) => {
+        const value = e.target.value.replace(/[^a-z0-9]/g, ""); // Using lowercase letters and numbers
+        setId(value);
+    };
+
+    const handlePasswordChange = (e) => {
+        const value = e.target.value.replace(/[^0-9]/g, ""); // Remove non-numeric characters
+        setPassword(value);
+    };
+
+    const handleConfirmChange = (e) => {
+        const value = e.target.value.replace(/[^0-9]/g, ""); // Remove non-numeric characters
+        setConfirm(value);
+    };
+
     const handleLogin = () => {
         // TODO: 로그인 처리 로직 작성
         console.log(`ID: ${id}, Password: ${password}`);
         // 로그인했으면 통과
+
+        //실패시 재시도
+        setTitle("wrong");
+        setPassword("");
+        setConfirm("");
+    };
+
+    const handleSignin = () => {
+        // TODO: 회원가입 처리 로직 작성
+        console.log(`ID: ${id}, Password: ${password}`);
 
         //실패시 재시도
         setTitle("wrong");
@@ -29,11 +54,11 @@ function Login({ closeModal }) {
                     {title === "wrong" ? <h2 className={`wrong`}>다시 시도해주세요!</h2> : <h2 className="title">10초면 가입할 수 있어요!</h2>}
                     <div className="box">
                         ID
-                        <input type="text" placeholder="ID" value={id} onChange={(e) => setId(e.target.value)} maxLength={10} />
+                        <input type="text" placeholder="ID" value={id} onChange={handleIdChange} maxLength={10} />
                     </div>
                     <div className="box">
                         Password
-                        <input type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} maxLength={4} />
+                        <input type="password" placeholder="Password" value={password} onChange={handlePasswordChange} maxLength={4} />
                     </div>
                     <div className="box">
                         <button onClick={handleLogin}>로그인</button>
@@ -68,18 +93,18 @@ function Login({ closeModal }) {
                     {title === "wrong" ? <h2 className={`wrong`}>다시 시도해주세요!</h2> : <h2 className="title">10초면 가입할 수 있어요!</h2>}
                     <div className="box">
                         ID
-                        <input type="text" placeholder="숫자와 소문자만 사용 가능합니다." value={id} onChange={(e) => setId(e.target.value)} maxLength={10} />
+                        <input type="text" placeholder="숫자와 소문자만 사용 가능합니다." value={id} onChange={handleIdChange} maxLength={10} />
                     </div>
                     <div className="box">
                         Password
-                        <input type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} maxLength={4} />
+                        <input type="password" placeholder="Password" value={password} onChange={handlePasswordChange} maxLength={4} />
                     </div>
                     <div className="box">
                         Confirm Password
-                        <input type="password" placeholder="Confirm Password" value={confirm} onChange={(e) => setConfirm(e.target.value)} maxLength={4} />
+                        <input type="password" placeholder="Confirm Password" value={confirm} onChange={handleConfirmChange} maxLength={4} />
                     </div>
                     <div className="box">
-                        <button onClick={handleLogin}>회원가입</button>
+                        <button onClick={handleSignin}>회원가입</button>
                     </div>
 
                     <div className="option">

--- a/src/components/Login/login.jsx
+++ b/src/components/Login/login.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import Modal from "react-modal";
 import "./login.css";
+import { NavLink } from "react-router-dom";
 
 Modal.setAppElement("#root");
 
@@ -106,7 +107,7 @@ function Login({ closeModal }) {
                             </a>
                         </p>
                         <p>
-                            <a href="/Journey">로그인 없이 사용할래요</a>
+                            <NavLink to="/journey">로그인 없이 사용할래요</NavLink>
                         </p>
                     </div>
                 </div>
@@ -177,7 +178,7 @@ function Login({ closeModal }) {
                             </a>
                         </p>
                         <p>
-                            <a href="/Journey">로그인 없이 사용할래요</a>
+                            <NavLink to="/journey">로그인 없이 사용할래요</NavLink>
                         </p>
                     </div>
                 </div>

--- a/src/components/Login/login.jsx
+++ b/src/components/Login/login.jsx
@@ -12,17 +12,17 @@ function Login({ closeModal }) {
     const [confirm, setConfirm] = useState("");
 
     const handleIdChange = (e) => {
-        const value = e.target.value.replace(/[^a-z0-9]/g, ""); // Using lowercase letters and numbers
+        const value = e.target.value;
         setId(value);
     };
 
     const handlePasswordChange = (e) => {
-        const value = e.target.value.replace(/[^0-9]/g, ""); // Remove non-numeric characters
+        const value = e.target.value;
         setPassword(value);
     };
 
     const handleConfirmChange = (e) => {
-        const value = e.target.value.replace(/[^0-9]/g, ""); // Remove non-numeric characters
+        const value = e.target.value;
         setConfirm(value);
     };
 
@@ -53,19 +53,39 @@ function Login({ closeModal }) {
 
     if (mode === "login") {
         return (
-            <Modal isOpen={true} onRequestClose={closeModal} shouldCloseOnOverlayClick={true} className="modal" overlayClassName="modal-overlay">
+            <Modal
+                isOpen={true}
+                onRequestClose={closeModal}
+                shouldCloseOnOverlayClick={true}
+                className="modal"
+                overlayClassName="modal-overlay"
+            >
                 <div className="background">
-                    {title === "wrong" ? <h2 className={`wrong`}>다시 시도해주세요!</h2> : <h2 className="title">10초면 가입할 수 있어요!</h2>}
+                    {title === "wrong" ? (
+                        <h2 className={`wrong`}>다시 시도해주세요!</h2>
+                    ) : (
+                        <h2 className="title">10초면 가입할 수 있어요!</h2>
+                    )}
                     <div className="box">
                         ID
                         <input type="text" placeholder="ID" value={id} onChange={handleIdChange} maxLength={10} />
                     </div>
                     <div className="box">
                         Password (4자리 숫자)
-                        <input type="password" placeholder="Password" value={password} onChange={handlePasswordChange} maxLength={4} />
+                        <input
+                            type="password"
+                            placeholder="Password"
+                            value={password}
+                            onChange={handlePasswordChange}
+                            maxLength={4}
+                        />
                     </div>
                     <div className="box">
-                        <button onClick={handleLogin} disabled={isSignUpDisabled} className={`signup-button ${isSignUpDisabled ? "disabled" : ""}`}>
+                        <button
+                            onClick={handleLogin}
+                            disabled={isSignUpDisabled}
+                            className={`signup-button ${isSignUpDisabled ? "disabled" : ""}`}
+                        >
                             로그인
                         </button>
                     </div>
@@ -94,23 +114,49 @@ function Login({ closeModal }) {
         );
     } else if (mode === "signin") {
         return (
-            <Modal isOpen={true} onRequestClose={closeModal} shouldCloseOnOverlayClick={true} className="modal" overlayClassName="modal-overlay">
+            <Modal
+                isOpen={true}
+                onRequestClose={closeModal}
+                shouldCloseOnOverlayClick={true}
+                className="modal"
+                overlayClassName="modal-overlay"
+            >
                 <div className="background">
-                    {title === "wrong" ? <h2 className={`wrong`}>다시 시도해주세요!</h2> : <h2 className="title">10초면 가입할 수 있어요!</h2>}
+                    {title === "wrong" ? (
+                        <h2 className={`wrong`}>다시 시도해주세요!</h2>
+                    ) : (
+                        <h2 className="title">10초면 가입할 수 있어요!</h2>
+                    )}
                     <div className="box">
                         ID (10자리 이내, 소문자와 숫자)
                         <input type="text" placeholder="ID" value={id} onChange={handleIdChange} maxLength={10} />
                     </div>
                     <div className="box">
                         Password (4자리 숫자)
-                        <input type="password" placeholder="Password" value={password} onChange={handlePasswordChange} maxLength={4} />
+                        <input
+                            type="password"
+                            placeholder="Password"
+                            value={password}
+                            onChange={handlePasswordChange}
+                            maxLength={4}
+                        />
                     </div>
                     <div className="box">
                         Confirm Password
-                        <input type="password" placeholder="Confirm Password" value={confirm} onChange={handleConfirmChange} maxLength={4} />
+                        <input
+                            type="password"
+                            placeholder="Confirm Password"
+                            value={confirm}
+                            onChange={handleConfirmChange}
+                            maxLength={4}
+                        />
                     </div>
                     <div className="box">
-                        <button onClick={handleSignin} disabled={isSignInDisabled} className={`signin-button ${isSignInDisabled ? "disabled" : ""}`}>
+                        <button
+                            onClick={handleSignin}
+                            disabled={isSignInDisabled}
+                            className={`signin-button ${isSignInDisabled ? "disabled" : ""}`}
+                        >
                             회원가입
                         </button>
                     </div>

--- a/src/components/Login/login.jsx
+++ b/src/components/Login/login.jsx
@@ -26,6 +26,10 @@ function Login({ closeModal }) {
         setConfirm(value);
     };
 
+    const isSignUpDisabled = id.length < 4 || password.length !== 4;
+
+    const isSignInDisabled = id.length < 4 || password.length !== 4 || confirm.length !== 4;
+
     const handleLogin = () => {
         // TODO: 로그인 처리 로직 작성
         console.log(`ID: ${id}, Password: ${password}`);
@@ -57,11 +61,13 @@ function Login({ closeModal }) {
                         <input type="text" placeholder="ID" value={id} onChange={handleIdChange} maxLength={10} />
                     </div>
                     <div className="box">
-                        Password
+                        Password (4자리 숫자)
                         <input type="password" placeholder="Password" value={password} onChange={handlePasswordChange} maxLength={4} />
                     </div>
                     <div className="box">
-                        <button onClick={handleLogin}>로그인</button>
+                        <button onClick={handleLogin} disabled={isSignUpDisabled} className={`signup-button ${isSignUpDisabled ? "disabled" : ""}`}>
+                            로그인
+                        </button>
                     </div>
 
                     <div className="option">
@@ -104,7 +110,9 @@ function Login({ closeModal }) {
                         <input type="password" placeholder="Confirm Password" value={confirm} onChange={handleConfirmChange} maxLength={4} />
                     </div>
                     <div className="box">
-                        <button onClick={handleSignin}>회원가입</button>
+                        <button onClick={handleSignin} disabled={isSignInDisabled} className={`signin-button ${isSignInDisabled ? "disabled" : ""}`}>
+                            회원가입
+                        </button>
                     </div>
 
                     <div className="option">

--- a/src/pages/EntryPage/index.jsx
+++ b/src/pages/EntryPage/index.jsx
@@ -4,7 +4,7 @@ import Login from "../../components/Login/login";
 function EntryPage() {
     return (
         <div>
-            <Login></Login>
+            <Login />
         </div>
     );
 }

--- a/src/pages/EntryPage/index.jsx
+++ b/src/pages/EntryPage/index.jsx
@@ -1,7 +1,14 @@
 import React from "react";
+import Login from "../../components/Login/login";
 
 function EntryPage() {
-    return <div>EntryPage</div>;
+    return (
+        <div>
+            <p>
+                <Login></Login>
+            </p>
+        </div>
+    );
 }
 
 export default EntryPage;

--- a/src/pages/EntryPage/index.jsx
+++ b/src/pages/EntryPage/index.jsx
@@ -4,9 +4,7 @@ import Login from "../../components/Login/login";
 function EntryPage() {
     return (
         <div>
-            <p>
-                <Login></Login>
-            </p>
+            <Login></Login>
         </div>
     );
 }


### PR DESCRIPTION
- width: 320px~500px에서 정상적으로 동작
-  로그인없이 볼래요 클릭시 Journey페이지로 입장
- ID는 10자리까지 입력받음 + 소문자와 숫자만 적용되게
- PW는 4자리까지만 입력받음 + 숫자만 입력되게 예외처리
- -> 더 받을 때 움직이면서 안됩니다 기능 넣을지 고민..

<img width="205" alt="image" src="https://github.com/Lv2-Recsys-01/styl-frontend/assets/69078499/da5adf46-942f-4dd6-8190-39482881e549">
<br>

1. 로그인 모달을 만들어서 Entry Page에 띄움.
- 백그라운 클릭 x, 반투명 배경 

<img width="205" alt="image" src="https://github.com/Lv2-Recsys-01/styl-frontend/assets/69078499/7d632e56-f364-4678-8a74-4a93526acfea">
<br>

3. 로그인 실패시 비밀번호만 리셋 후, 새로운  title문구가 나옴( 다시 시도하세요로 바뀌게 작성)

<img width="205" alt="image" src="https://github.com/Lv2-Recsys-01/styl-frontend/assets/69078499/e3d0946e-060c-48a7-a0b6-fce34e83f2ba">
<br>

4. 회원가입할래요 클릭시 위의 화면으로 이동 -> Confirm Password추가
5. 로그인할래요 클릭시 로그인 페이지로 이동 

<br><br>
구현해야되는 기능
- 로그인 API와 연결하여 login 동작 구현 
- 회원가입 API 연결 
- 회원가입 실패시 안내 방향
-  ID 문구 수정을 어떻게 할 지 정하기 등 실패 시 동작 메뉴얼 정하기

구현하면 좋을 기능
- Journey 페이지에서 상단 login 버튼을 눌러서 접근시에는 해당 페이지 위에 띄우고 백그라운 클릭 및 로그인 없이 사용하기 클릭 시 기존에 보던 화면으로 전환(x버튼으로 구현할 수도)
